### PR TITLE
Enhance dashboard and surah layouts

### DIFF
--- a/components/CommunityCard.tsx
+++ b/components/CommunityCard.tsx
@@ -1,18 +1,36 @@
 import React from 'react';
 import { HiOutlineUsers } from 'react-icons/hi';
+import { Link } from 'react-router-dom';
 
-const groups = ['Quran Lovers', 'Ramadan Circle', 'TPO Muslims'];
+interface Group {
+  name: string;
+  members: number;
+}
+
+const groups: Group[] = [
+  { name: 'Quran Lovers', members: 120 },
+  { name: 'Ramadan Circle', members: 80 },
+  { name: 'TPO Muslims', members: 64 },
+];
 
 const CommunityCard = () => (
   <div className="bg-white p-5 rounded-2xl shadow-lg shadow-brand-cyan/10">
-    <h3 className="font-semibold text-lg mb-4 flex items-center gap-2 text-brand-dark">
-      <HiOutlineUsers className="w-5 h-5 text-brand-cyan" />
-      Community
-    </h3>
+    <div className="flex items-center justify-between mb-4">
+      <h3 className="font-semibold text-lg flex items-center gap-2 text-brand-dark">
+        <HiOutlineUsers className="w-5 h-5 text-brand-cyan" />
+        Community
+      </h3>
+      <Link to="/community" className="text-sm text-brand-cyan font-medium">
+        See All
+      </Link>
+    </div>
     <ul className="space-y-2">
       {groups.map(g => (
-        <li key={g} className="flex items-center justify-between">
-          <span className="text-brand-dark">{g}</span>
+        <li key={g.name} className="flex items-center justify-between">
+          <div>
+            <span className="block text-brand-dark">{g.name}</span>
+            <span className="text-xs text-brand-gray">{g.members} members</span>
+          </div>
           <button className="text-sm text-brand-cyan font-medium">Join</button>
         </li>
       ))}

--- a/components/ScheduleCard.tsx
+++ b/components/ScheduleCard.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
 import { HiOutlineCalendar, HiOutlineBookOpen } from 'react-icons/hi';
+import { Link } from 'react-router-dom';
 
 interface ScheduleItem {
   title: string;
   time: string;
+  date: string;
 }
 
 const sampleSchedule: ScheduleItem[] = [
-  { title: 'Quran Juz 1', time: '06:00' },
-  { title: 'Quran Juz 2', time: '07:00' },
+  { title: 'Quran Juz 1', time: '06:00', date: 'Feb 21' },
+  { title: 'Quran Juz 2', time: '07:00', date: 'Feb 22' },
 ];
 
 const ScheduleCard = () => (
   <div className="bg-white p-5 rounded-2xl shadow-lg shadow-brand-cyan/10">
-    <h3 className="font-semibold text-lg mb-4 flex items-center gap-2 text-brand-dark">
-      <HiOutlineCalendar className="w-5 h-5 text-brand-cyan" />
-      My Schedule
-    </h3>
+    <div className="flex items-center justify-between mb-4">
+      <h3 className="font-semibold text-lg flex items-center gap-2 text-brand-dark">
+        <HiOutlineCalendar className="w-5 h-5 text-brand-cyan" />
+        My Schedule
+      </h3>
+      <Link to="/full-schedule" className="text-sm text-brand-cyan font-medium">
+        See All
+      </Link>
+    </div>
     <ul className="space-y-3">
       {sampleSchedule.map((item, idx) => (
         <li key={idx} className="flex items-center justify-between bg-brand-light rounded-xl px-4 py-2">
@@ -24,7 +31,10 @@ const ScheduleCard = () => (
             <HiOutlineBookOpen className="w-5 h-5 text-brand-cyan" />
             <span className="font-medium text-brand-dark">{item.title}</span>
           </div>
-          <span className="text-sm text-brand-gray">{item.time}</span>
+          <div className="text-right">
+            <span className="block text-sm text-brand-gray">{item.time}</span>
+            <span className="block text-xs text-brand-gray">{item.date}</span>
+          </div>
         </li>
       ))}
     </ul>

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -65,7 +65,7 @@ const HomePage = () => {
       <main className="p-4 space-y-6 flex-1 overflow-y-auto pb-24">
         <div>
           <p className="text-brand-gray dark:text-gray-400">Assalamualaikum</p>
-          <h1 className="text-2xl font-bold text-brand-dark dark:text-white">Welcome, {profile.name}!</h1>
+          <h1 className="text-2xl font-bold text-brand-dark dark:text-white">{profile.name}</h1>
         </div>
         <CompletionCard />
         <ScheduleCard />

--- a/pages/SurahDetailPage.tsx
+++ b/pages/SurahDetailPage.tsx
@@ -4,7 +4,7 @@ import type { SurahFullData, LastRead, Ayah, Bookmarks, Notes, Surah } from '../
 import { fetchSurahDetail, fetchSurahs } from '../services/quranApi';
 import useLocalStorage from '../hooks/useLocalStorage';
 import LoadingSpinner from '../components/LoadingSpinner';
-import { ArrowLeftIcon, BookmarkIcon } from '../components/Icons';
+import { ArrowLeftIcon, BookmarkIcon, PlayCircleIcon, PauseCircleIcon } from '../components/Icons';
 // import AyahRow from '../components/AyahRow';
 import { JUZ_DATA, HIZB_DATA } from '../constants';
 import { SettingsContext } from '../contexts/SettingsContext';
@@ -522,11 +522,11 @@ const SurahDetailPage = () => {
                 <div className="bg-white dark:bg-gray-800 sepia-card-bg rounded-2xl p-4 md:p-8 shadow-lg max-w-2xl w-full mx-auto border border-gray-100">
                     {/* Surah playback controls */}
                     <div className="flex items-center justify-between mb-4">
-                        <div>
-                            <button className="px-3 py-1 bg-brand-cyan text-white rounded mr-2" onClick={handleSurahPlayPause}>
-                                {isSurahPlaying ? 'Pause Surah' : 'Play Surah'}
+                        <div className="flex items-center gap-2">
+                            <button className="p-2 bg-brand-cyan text-white rounded-full" onClick={handleSurahPlayPause}>
+                                {isSurahPlaying ? <PauseCircleIcon className="w-8 h-8" /> : <PlayCircleIcon className="w-8 h-8" />}
                             </button>
-                            <select value={playbackRate} onChange={e => setPlaybackRate(Number(e.target.value))} className="ml-2 px-2 py-1 rounded border text-sm">
+                            <select value={playbackRate} onChange={e => setPlaybackRate(Number(e.target.value))} className="px-2 py-1 rounded border text-sm">
                                 <option value="0.5">0.5x</option>
                                 <option value="0.75">0.75x</option>
                                 <option value="1">1x</option>
@@ -558,34 +558,28 @@ const SurahDetailPage = () => {
                         </div>
                     )}
 
-                                        {/* Arabic text block with styled ayah numbers as badges */}
-                                        <div className="flex flex-col items-center mb-8">
-                                            <div className="text-center arabic-text text-3xl leading-loose text-brand-dark dark:text-white sepia-text" dir="rtl" style={{ wordSpacing: '0.5em', lineHeight: 2.2 }}>
-                                                {surahData.arabicAyahs.map((ayah, index) => (
-                                                    <React.Fragment key={ayah.numberInSurah}>
-                                                        {ayah.text}
-                                                                                                                <button
-                                                                                                                    type="button"
-                                                                                                                    className="inline-flex items-center justify-center mx-1 w-8 h-8 rounded-full border-2 border-brand-cyan text-brand-cyan font-bold bg-white dark:bg-gray-900 hover:bg-brand-cyan hover:text-white cursor-pointer transition-all shadow-sm align-middle focus:outline-none focus:ring-2 focus:ring-brand-cyan"
-                                                                                                                    style={{ verticalAlign: 'middle', fontSize: '1.1rem' }}
-                                                                                                                    aria-label={`Ayah ${ayah.numberInSurah} options`}
-                                                                                                                    onClick={e => setAyahPopover({ ayah, index, anchor: e.currentTarget })}
-                                                                                                                >
-                                                                                                                    {ayah.numberInSurah}
-                                                                                                                </button>
-                                                    </React.Fragment>
-                                                ))}
-                                            </div>
-                                        </div>
-
-                                        {/* Translation block */}
-                                        <div className="space-y-4 px-2 md:px-8">
-                                            {surahData.translationAyahs.map((tAyah, idx) => (
-                                                <div key={tAyah.numberInSurah} className="text-base text-brand-gray dark:text-gray-400 sepia-text-light leading-relaxed">
-                                                    {tAyah.text}
-                                                </div>
-                                            ))}
-                                        </div>
+                    {/* Verses with translations */}
+                    <div className="space-y-8">
+                        {surahData.arabicAyahs.map((ayah, index) => (
+                            <div key={ayah.numberInSurah} className="mb-4">
+                                <div className="text-right arabic-text text-3xl leading-loose text-brand-dark dark:text-white sepia-text" dir="rtl" style={{ wordSpacing: '0.5em', lineHeight: 2.2 }}>
+                                    {ayah.text}
+                                    <button
+                                        type="button"
+                                        className="inline-flex items-center justify-center mx-1 w-8 h-8 rounded-full border-2 border-brand-cyan text-brand-cyan font-bold bg-white dark:bg-gray-900 hover:bg-brand-cyan hover:text-white cursor-pointer transition-all shadow-sm align-middle focus:outline-none focus:ring-2 focus:ring-brand-cyan"
+                style={{ verticalAlign: 'middle', fontSize: '1.1rem' }}
+                                        aria-label={`Ayah ${ayah.numberInSurah} options`}
+                                        onClick={e => setAyahPopover({ ayah, index, anchor: e.currentTarget })}
+                                    >
+                                        {ayah.numberInSurah}
+                                    </button>
+                                </div>
+                                <div className="text-base text-brand-gray dark:text-gray-400 sepia-text-light leading-relaxed mt-2" dir="ltr">
+                                    {surahData.translationAyahs[index]?.text}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
                 </div>
             </main>
         </div>

--- a/pages/SurahListPage.tsx
+++ b/pages/SurahListPage.tsx
@@ -39,8 +39,11 @@ const SurahListItem = ({ surah, appLang, searchTerm }: { surah: Surah, appLang: 
         <div className="flex items-center gap-4">
             <NumberingWrapper number={surah.number} />
             <div>
-                <h3 className="font-bold text-brand-dark dark:text-white">{highlight(surah.englishName, searchTerm)}</h3>
-                <p className="text-xs text-brand-gray dark:text-gray-500 uppercase">{surah.revelationType} &bull; {surah.numberOfAyahs} {uiT[appLang].surah}</p>
+                <h3 className="font-bold text-brand-dark dark:text-white">
+                    {highlight(surah.englishName, searchTerm)}
+                    <span className="font-normal text-brand-gray dark:text-gray-500 ml-2">{surah.englishNameTranslation}</span>
+                </h3>
+                <p className="text-xs text-brand-gray dark:text-gray-500">{surah.numberOfAyahs} verses</p>
             </div>
         </div>
         <div className="text-right">
@@ -142,9 +145,9 @@ const SurahListPage = () => {
                         placeholder={`Search ${activeTab}..`}
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
-                        className="w-full pl-10 pr-4 py-3 bg-slate-100 dark:bg-gray-800 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-cyan focus-visible:ring-4"
+                        className="w-full pl-4 pr-10 py-3 bg-slate-100 dark:bg-gray-800 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-cyan focus-visible:ring-4"
                     />
-                    <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-brand-gray" />
+                    <SearchIcon className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-brand-gray" />
                 </div>
             </header>
 


### PR DESCRIPTION
## Summary
- add 'See All' links and richer sample data for schedule and community cards
- display surah name translations and verse counts in list items with right-aligned search icon
- interleave translations with Arabic text and use icon play button on surah detail page

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a5563d8ce8832b85aaaf73d90d7732